### PR TITLE
Update gen_network_code.rb

### DIFF
--- a/gen_network_code.rb
+++ b/gen_network_code.rb
@@ -1,4 +1,5 @@
 require 'json'
+require 'active_support'
 require 'active_support/core_ext'
 
 class KotlinCodeGenerator
@@ -374,6 +375,7 @@ class SwaggerConvertor
   end
 
   def parse_req_res_schema(data)
+    return {} if data['content'].nil?
     data['content']['application/json']['schema']
   end
 


### PR DESCRIPTION
First, 'active_support' is required to run the script with an actual ruby installation.
Second, if a request, such a POST, isn't returning any data, the parser raises an exception, due to the fact that the 'content' part in the response schema is missing.